### PR TITLE
Migrate to Heroku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/heroku/heroku-buildpack-python.git#v99

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --workers=2 --bind=0.0.0.0 oxlos.wsgi:application
+web: gunicorn oxlos.wsgi:application

--- a/gondor.yml
+++ b/gondor.yml
@@ -1,7 +1,0 @@
-site: jtauber/oxlos2
-branches:
-  master: primary
-deploy:
-  services:
-  - web
-buildpack: https://github.com/heroku/heroku-buildpack-multi.git

--- a/oxlos/settings.py
+++ b/oxlos/settings.py
@@ -16,7 +16,7 @@ DATABASES = {
 ALLOWED_HOSTS = [
     "localhost",
     "oxlos.org",
-    os.environ.get("GONDOR_INSTANCE_DOMAIN")
+    ".herokuapp.com",
 ]
 
 # Local time zone for this installation. Choices can be found here:

--- a/oxlos/settings.py
+++ b/oxlos/settings.py
@@ -107,6 +107,7 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -214,3 +215,6 @@ AUTHENTICATION_BACKENDS = [
 
 THEME_CONTACT_EMAIL = "jtauber@jtauber.com"
 DEFAULT_FROM_EMAIL = "jtauber@jtauber.com"
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_SSL_REDIRECT = True

--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
     "onchange": "3.2.1",
     "uglifyjs": "2.4.11",
     "watchify": "3.9.0"
-  }
+  },
+  "heroku-run-build-script": true
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "type": "git",
     "url": "https://github.com/pinax/pinax-project"
   },
+  "engines": {
+    "node": "6.11.0",
+    "npm": "3.10.10"
+  },
   "scripts": {
     "clean": "rm -rf static/dist && mkdir -p static/dist/js && mkdir -p static/dist/css && mkdir -p static/dist/fonts && mkdir -p static/dist/images",
     "watch:babel": "babel static/src/js --out-dir static/dist/js --quiet --watch",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ pinax-invitations==4.0.4
 
 dj-database-url==0.4.2
 gunicorn==19.7.1
-psycopg2==2.7.1
+psycopg2==2.7.7
 whitenoise==3.3.0
 raven==6.1.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.8


### PR DESCRIPTION
- Latest Python 3.6.x
- Add ACM and enforce TLS